### PR TITLE
servantes: allow multiple users to deploy to the same cluster

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -26,12 +26,18 @@ Here's a quick rundown of these services and their properties:
 def servantes():
   return composite_service([fe, vigoda, fortune, doggos, snack, hypothesizer, spoonerisms])
 
+def get_username():
+  return local('whoami').rstrip('\n')
+
+def m4_yaml(file):
+  return local('m4 "' + file + '" -DOWNER="' + get_username() + '"')
+
 def fe():
-  yaml = read_file('fe/deployments/fe.yaml')
+  yaml = m4_yaml('fe/deployments/fe.yaml')
 
   image_name = 'gcr.io/windmill-public-containers/servantes/fe'
 
-  start_fast_build('Dockerfile.go.base', image_name)
+  start_fast_build('Dockerfile.go.base', image_name, '/go/bin/fe --owner ' + get_username())
   path = '/go/src/github.com/windmilleng/servantes/fe'
   repo = local_git_repo('.')
   add(repo.path('fe'), path)
@@ -42,7 +48,7 @@ def fe():
   return k8s_service(yaml, img)
 
 def vigoda():
-  yaml = read_file('vigoda/deployments/vigoda.yaml')
+  yaml = m4_yaml('vigoda/deployments/vigoda.yaml')
 
   image_name = 'gcr.io/windmill-public-containers/servantes/vigoda'
 
@@ -57,7 +63,7 @@ def vigoda():
   return k8s_service(yaml, img)
 
 def snack():
-  yaml = read_file('snack/deployments/snack.yaml')
+  yaml = m4_yaml('snack/deployments/snack.yaml')
 
   image_name = 'gcr.io/windmill-public-containers/servantes/snack'
 
@@ -72,7 +78,7 @@ def snack():
   return k8s_service(yaml, img)
 
 def doggos():
-  yaml = read_file('doggos/deployments/doggos.yaml')
+  yaml = m4_yaml('doggos/deployments/doggos.yaml')
 
   image_name = 'gcr.io/windmill-public-containers/servantes/doggos'
 
@@ -87,7 +93,7 @@ def doggos():
   return k8s_service(yaml, img)
 
 def fortune():
-  yaml = read_file('fortune/deployments/fortune.yaml')
+  yaml = m4_yaml('fortune/deployments/fortune.yaml')
 
   image_name = 'gcr.io/windmill-public-containers/servantes/fortune'
 
@@ -103,7 +109,7 @@ def fortune():
   return k8s_service(yaml, img)
 
 def hypothesizer():
-  yaml = read_file('hypothesizer/deployments/hypothesizer.yaml')
+  yaml = m4_yaml('hypothesizer/deployments/hypothesizer.yaml')
 
   image_name = 'gcr.io/windmill-public-containers/servantes/hypothesizer'
 
@@ -117,7 +123,7 @@ def hypothesizer():
   return k8s_service(yaml, img)
 
 def spoonerisms():
-  yaml = read_file('spoonerisms/deployments/spoonerisms.yaml')
+  yaml = m4_yaml('spoonerisms/deployments/spoonerisms.yaml')
 
   image_name = 'gcr.io/windmill-public-containers/servantes/spoonerisms'
 

--- a/doggos/deployments/doggos.yaml
+++ b/doggos/deployments/doggos.yaml
@@ -1,15 +1,17 @@
 apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
-  name: doggos
+  name: OWNER-doggos
   labels:
     app: doggos
+    owner: OWNER
 spec:
   template:
     metadata:
       labels:
         app: doggos
         tier: web
+        owner: OWNER
     spec:
       containers:
       - name: doggos
@@ -24,9 +26,10 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: doggos
+  name: OWNER-doggos
   labels:
     app: doggos
+    owner: OWNER
 spec:
   ports:
     - port: 80
@@ -34,3 +37,4 @@ spec:
       protocol: TCP
   selector:
     app: doggos
+    owner: OWNER

--- a/fe/deployments/fe.yaml
+++ b/fe/deployments/fe.yaml
@@ -1,20 +1,21 @@
 apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
-  name: fe
+  name: OWNER-fe
   labels:
     app: fe
+    owner: OWNER
 spec:
   template:
     metadata:
       labels:
         app: fe
         tier: web
+        owner: OWNER
     spec:
       containers:
       - name: fe
         image: gcr.io/windmill-public-containers/servantes/fe
-        command: ["/go/bin/fe"]
         env:
         - name: TEMPLATE_DIR
           value: "/go/src/github.com/windmilleng/servantes/fe/web/templates"
@@ -24,9 +25,10 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: fe
+  name: OWNER-fe
   labels:
     app: fe
+    owner: OWNER
 spec:
   type: LoadBalancer
   ports:
@@ -35,6 +37,7 @@ spec:
       protocol: TCP
   selector:
     app: fe
+    owner: OWNER
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1

--- a/fortune/deployments/fortune.yaml
+++ b/fortune/deployments/fortune.yaml
@@ -1,15 +1,17 @@
 apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
-  name: fortune
+  name: OWNER-fortune
   labels:
     app: fortune
+    owner: OWNER
 spec:
   template:
     metadata:
       labels:
         app: fortune
         tier: web
+        owner: OWNER
     spec:
       containers:
       - name: fortune
@@ -24,9 +26,10 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: fortune
+  name: OWNER-fortune
   labels:
     app: fortune
+    owner: OWNER
 spec:
   ports:
     - port: 80
@@ -34,3 +37,4 @@ spec:
       protocol: TCP
   selector:
     app: fortune
+    owner: OWNER

--- a/hypothesizer/deployments/hypothesizer.yaml
+++ b/hypothesizer/deployments/hypothesizer.yaml
@@ -1,15 +1,17 @@
 apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
-  name: hypothesizer
+  name: OWNER-hypothesizer
   labels:
     app: hypothesizer
+    owner: OWNER
 spec:
   template:
     metadata:
       labels:
         app: hypothesizer
         tier: web
+        owner: OWNER
     spec:
       containers:
       - name: hypothesizer
@@ -21,9 +23,10 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: hypothesizer
+  name: OWNER-hypothesizer
   labels:
     app: hypothesizer
+    owner: OWNER
 spec:
   ports:
     - port: 80
@@ -31,3 +34,4 @@ spec:
       protocol: TCP
   selector:
     app: hypothesizer
+    owner: OWNER

--- a/snack/deployments/snack.yaml
+++ b/snack/deployments/snack.yaml
@@ -1,15 +1,17 @@
 apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
-  name: snack
+  name: OWNER-snack
   labels:
     app: snack
+    owner: OWNER
 spec:
   template:
     metadata:
       labels:
         app: snack
         tier: web
+        owner: OWNER
     spec:
       containers:
       - name: snack
@@ -24,9 +26,10 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: snack
+  name: OWNER-snack
   labels:
     app: snack
+    owner: OWNER
 spec:
   ports:
     - port: 80
@@ -34,3 +37,4 @@ spec:
       protocol: TCP
   selector:
     app: snack
+    owner: OWNER

--- a/spoonerisms/deployments/spoonerisms.yaml
+++ b/spoonerisms/deployments/spoonerisms.yaml
@@ -1,15 +1,17 @@
 apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
-  name: spoonerisms
+  name: OWNER-spoonerisms
   labels:
     app: spoonerisms
+    owner: OWNER
 spec:
   template:
     metadata:
       labels:
         app: spoonerisms
         tier: web
+        owner: OWNER
     spec:
       containers:
       - name: spoonerisms
@@ -21,9 +23,10 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: spoonerisms
+  name: OWNER-spoonerisms
   labels:
     app: spoonerisms
+    owner: OWNER
 spec:
   ports:
     - port: 80
@@ -31,3 +34,4 @@ spec:
       protocol: TCP
   selector:
     app: spoonerisms
+    owner: OWNER

--- a/vigoda/deployments/vigoda.yaml
+++ b/vigoda/deployments/vigoda.yaml
@@ -1,15 +1,17 @@
 apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
-  name: vigoda
+  name: OWNER-vigoda
   labels:
     app: vigoda
+    owner: OWNER
 spec:
   template:
     metadata:
       labels:
         app: vigoda
         tier: web
+        owner: OWNER
     spec:
       containers:
       - name: vigoda
@@ -24,9 +26,10 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: vigoda
+  name: OWNER-vigoda
   labels:
     app: vigoda
+    owner: OWNER
 spec:
   ports:
     - port: 80
@@ -34,3 +37,4 @@ spec:
       protocol: TCP
   selector:
     app: vigoda
+    owner: OWNER


### PR DESCRIPTION
I tried this with and without kustomize.

You can see a version with kustomize [here](https://github.com/windmilleng/servantes/commit/ac716da7a833ca8cc561ea4cec5990221233b326).

Either way, we're using m4 to get username in there. It's mostly a matter of whether it's worth adding a dep on kustomize to save a bit of repetition.

We could avoid m4 by using `kustomize edit`, e.g., `cd fe/deployments && kustomize edit set namePrefix matt`, but that modifies files on disk, and then we have to figure out how to restore them.

I've probably spent too much time on this already, and this is working, so I'm inclined to call this done for now, and worry about kustomize later.

(for posterity - I found [this](https://github.com/kubernetes/kubernetes/issues/23896#issuecomment-313544857) pretty extensive list of tools for templating k8s configs. I looked through a dozen or so and didn't see any that seemed like significant improvements over m4 for this use case).