### PR TITLE
servantes: reduce cpu request to 10m

### DIFF
--- a/doggos/deployments/doggos.yaml
+++ b/doggos/deployments/doggos.yaml
@@ -22,6 +22,9 @@ spec:
           value: "/go/src/github.com/windmilleng/servantes/doggos/web/templates"
         ports:
         - containerPort: 8083
+        resources:
+          requests:
+            cpu: "10m"
 ---
 apiVersion: v1
 kind: Service

--- a/emoji/deployments/emoji.yaml
+++ b/emoji/deployments/emoji.yaml
@@ -22,6 +22,9 @@ spec:
           value: "/go/src/github.com/windmilleng/servantes/emoji/web/templates"
         ports:
         - containerPort: 8081
+        resources:
+          requests:
+            cpu: "10m"
 ---
 apiVersion: v1
 kind: Service

--- a/fe/deployments/fe.yaml
+++ b/fe/deployments/fe.yaml
@@ -21,6 +21,9 @@ spec:
           value: "/go/src/github.com/windmilleng/servantes/fe/web/templates"
         ports:
         - containerPort: 8080
+        resources:
+          requests:
+            cpu: "10m"
 ---
 apiVersion: v1
 kind: Service

--- a/fortune/deployments/fortune.yaml
+++ b/fortune/deployments/fortune.yaml
@@ -22,6 +22,9 @@ spec:
           value: "/go/src/github.com/windmilleng/servantes/fortune/web/templates"
         ports:
         - containerPort: 8082
+        resources:
+          requests:
+            cpu: "10m"
 ---
 apiVersion: v1
 kind: Service

--- a/hypothesizer/deployments/hypothesizer.yaml
+++ b/hypothesizer/deployments/hypothesizer.yaml
@@ -19,6 +19,9 @@ spec:
         command: ["python", "/app/app.py"]
         ports:
         - containerPort: 5000
+        resources:
+          requests:
+            cpu: "10m"
 ---
 apiVersion: v1
 kind: Service

--- a/snack/deployments/snack.yaml
+++ b/snack/deployments/snack.yaml
@@ -22,6 +22,9 @@ spec:
           value: "/go/src/github.com/windmilleng/servantes/snack/web/templates"
         ports:
         - containerPort: 8083
+        resources:
+          requests:
+            cpu: "10m"
 ---
 apiVersion: v1
 kind: Service

--- a/spoonerisms/deployments/spoonerisms.yaml
+++ b/spoonerisms/deployments/spoonerisms.yaml
@@ -19,6 +19,9 @@ spec:
         command: ["node", "/app/index.js"]
         ports:
         - containerPort: 5000
+        resources:
+          requests:
+            cpu: "10m"
 ---
 apiVersion: v1
 kind: Service

--- a/vigoda/deployments/vigoda.yaml
+++ b/vigoda/deployments/vigoda.yaml
@@ -22,6 +22,9 @@ spec:
           value: "/go/src/github.com/windmilleng/servantes/vigoda/web/templates"
         ports:
         - containerPort: 8081
+        resources:
+          requests:
+            cpu: "10m"
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
Servantes services were previously requesting the default of 100m (1/10 of a CPU), which meant each person who deployed the system took up most of a full node.