### PR TITLE
Record kubernetes yaml reads

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -33,6 +33,7 @@ def get_username():
   return local('whoami').rstrip('\n')
 
 def m4_yaml(file):
+  read_file(file)
   return local('m4 -DOWNER=%s %s' % (repr(get_username()), repr(file)))
 
 def fe():


### PR DESCRIPTION
This is required so that we know to reload a manifest when a constituent kubernetes yaml file changes.