### PR TITLE
Add skaffold config for snack, make all yaml valid without running m4

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -31,7 +31,7 @@ def get_username():
 
 def m4_yaml(file):
   read_file(file)
-  return local('m4 -DOWNER=%s %s' % (repr(get_username()), repr(file)))
+  return local('m4 -Dvarowner=%s %s' % (repr(get_username()), repr(file)))
 
 global_yaml(m4_yaml('./global.yaml'))
 

--- a/doggos/deployments/doggos.yaml
+++ b/doggos/deployments/doggos.yaml
@@ -4,18 +4,18 @@ metadata:
   name: varowner-doggos
   labels:
     app: doggos
-    varowner: varowner
+    owner: varowner
 spec:
   selector:
     matchLabels:
       app: doggos
-      varowner: varowner
+      owner: varowner
   template:
     metadata:
       labels:
         app: doggos
         tier: web
-        varowner: varowner
+        owner: varowner
     spec:
       containers:
       - name: doggos

--- a/doggos/deployments/doggos.yaml
+++ b/doggos/deployments/doggos.yaml
@@ -1,21 +1,21 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: OWNER-doggos
+  name: varowner-doggos
   labels:
     app: doggos
-    owner: OWNER
+    varowner: varowner
 spec:
   selector:
     matchLabels:
       app: doggos
-      owner: OWNER
+      varowner: varowner
   template:
     metadata:
       labels:
         app: doggos
         tier: web
-        owner: OWNER
+        varowner: varowner
     spec:
       containers:
       - name: doggos

--- a/emoji/deployments/emoji.yaml
+++ b/emoji/deployments/emoji.yaml
@@ -1,21 +1,21 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: OWNER-emoji
+  name: varowner-emoji
   labels:
     app: emoji
-    owner: OWNER
+    varowner: varowner
 spec:
   selector:
     matchLabels:
       app: emoji
-      owner: OWNER
+      varowner: varowner
   template:
     metadata:
       labels:
         app: emoji
         tier: web
-        owner: OWNER
+        varowner: varowner
     spec:
       containers:
       - name: emoji

--- a/emoji/deployments/emoji.yaml
+++ b/emoji/deployments/emoji.yaml
@@ -4,18 +4,18 @@ metadata:
   name: varowner-emoji
   labels:
     app: emoji
-    varowner: varowner
+    owner: varowner
 spec:
   selector:
     matchLabels:
       app: emoji
-      varowner: varowner
+      owner: varowner
   template:
     metadata:
       labels:
         app: emoji
         tier: web
-        varowner: varowner
+        owner: varowner
     spec:
       containers:
       - name: emoji

--- a/fe/deployments/fe.yaml
+++ b/fe/deployments/fe.yaml
@@ -1,21 +1,21 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: OWNER-fe
+  name: varowner-fe
   labels:
     app: fe
-    owner: OWNER
+    varowner: varowner
 spec:
   selector:
     matchLabels:
       app: fe
-      owner: OWNER
+      varowner: varowner
   template:
     metadata:
       labels:
         app: fe
         tier: web
-        owner: OWNER
+        varowner: varowner
     spec:
       containers:
       - name: fe
@@ -32,10 +32,10 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: OWNER-fe
+  name: varowner-fe
   labels:
     app: fe
-    owner: OWNER
+    varowner: varowner
 spec:
   type: LoadBalancer
   ports:
@@ -44,7 +44,7 @@ spec:
       protocol: TCP
   selector:
     app: fe
-    owner: OWNER
+    varowner: varowner
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1

--- a/fe/deployments/fe.yaml
+++ b/fe/deployments/fe.yaml
@@ -4,18 +4,18 @@ metadata:
   name: varowner-fe
   labels:
     app: fe
-    varowner: varowner
+    owner: varowner
 spec:
   selector:
     matchLabels:
       app: fe
-      varowner: varowner
+      owner: varowner
   template:
     metadata:
       labels:
         app: fe
         tier: web
-        varowner: varowner
+        owner: varowner
     spec:
       containers:
       - name: fe
@@ -35,7 +35,7 @@ metadata:
   name: varowner-fe
   labels:
     app: fe
-    varowner: varowner
+    owner: varowner
 spec:
   type: LoadBalancer
   ports:
@@ -44,7 +44,7 @@ spec:
       protocol: TCP
   selector:
     app: fe
-    varowner: varowner
+    owner: varowner
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1

--- a/fortune/deployments/fortune.yaml
+++ b/fortune/deployments/fortune.yaml
@@ -1,21 +1,21 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: OWNER-fortune
+  name: varowner-fortune
   labels:
     app: fortune
-    owner: OWNER
+    varowner: varowner
 spec:
   selector:
     matchLabels:
       app: fortune
-      owner: OWNER
+      varowner: varowner
   template:
     metadata:
       labels:
         app: fortune
         tier: web
-        owner: OWNER
+        varowner: varowner
     spec:
       containers:
       - name: fortune
@@ -27,7 +27,7 @@ spec:
         - name: THE_SECRET
           valueFrom:
             secretKeyRef:
-              name: OWNER-servantes-stuff
+              name: varowner-servantes-stuff
               key: things
         ports:
         - containerPort: 8082

--- a/fortune/deployments/fortune.yaml
+++ b/fortune/deployments/fortune.yaml
@@ -4,18 +4,18 @@ metadata:
   name: varowner-fortune
   labels:
     app: fortune
-    varowner: varowner
+    owner: varowner
 spec:
   selector:
     matchLabels:
       app: fortune
-      varowner: varowner
+      owner: varowner
   template:
     metadata:
       labels:
         app: fortune
         tier: web
-        varowner: varowner
+        owner: varowner
     spec:
       containers:
       - name: fortune

--- a/global.yaml
+++ b/global.yaml
@@ -1,21 +1,21 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: OWNER-secrets
+  name: varowner-secrets
   labels:
     app: secrets
-    owner: OWNER
+    varowner: varowner
 spec:
   selector:
     matchLabels:
       app: secrets
-      owner: OWNER
+      varowner: varowner
   template:
     metadata:
       labels:
         app: secrets
         tier: web
-        owner: OWNER
+        varowner: varowner
     spec:
       containers:
       - name: secrets
@@ -27,7 +27,7 @@ spec:
         - name: THE_SECRET
           valueFrom:
             secretKeyRef:
-              name: OWNER-servantes-stuff
+              name: varowner-servantes-stuff
               key: stuff
         ports:
         - containerPort: 8081
@@ -38,10 +38,10 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: OWNER-secrets
+  name: varowner-secrets
   labels:
     app: secrets
-    owner: OWNER
+    varowner: varowner
 spec:
   ports:
   - port: 80
@@ -49,12 +49,12 @@ spec:
     protocol: TCP
   selector:
     app: secrets
-    owner: OWNER
+    varowner: varowner
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: OWNER-servantes-stuff
+  name: varowner-servantes-stuff
 type: Opaque
 data:
   stuff: aGVsbG8gd29ybGQ=

--- a/global.yaml
+++ b/global.yaml
@@ -4,18 +4,18 @@ metadata:
   name: varowner-secrets
   labels:
     app: secrets
-    varowner: varowner
+    owner: varowner
 spec:
   selector:
     matchLabels:
       app: secrets
-      varowner: varowner
+      owner: varowner
   template:
     metadata:
       labels:
         app: secrets
         tier: web
-        varowner: varowner
+        owner: varowner
     spec:
       containers:
       - name: secrets
@@ -41,7 +41,7 @@ metadata:
   name: varowner-secrets
   labels:
     app: secrets
-    varowner: varowner
+    owner: varowner
 spec:
   ports:
   - port: 80
@@ -49,7 +49,7 @@ spec:
     protocol: TCP
   selector:
     app: secrets
-    varowner: varowner
+    owner: varowner
 ---
 apiVersion: v1
 kind: Secret

--- a/hypothesizer/deployments/hypothesizer.yaml
+++ b/hypothesizer/deployments/hypothesizer.yaml
@@ -4,18 +4,18 @@ metadata:
   name: varowner-hypothesizer
   labels:
     app: hypothesizer
-    varowner: varowner
+    owner: varowner
 spec:
   selector:
     matchLabels:
       app: hypothesizer
-      varowner: varowner
+      owner: varowner
   template:
     metadata:
       labels:
         app: hypothesizer
         tier: web
-        varowner: varowner
+        owner: varowner
     spec:
       containers:
       - name: hypothesizer
@@ -33,7 +33,7 @@ metadata:
   name: varowner-hypothesizer
   labels:
     app: hypothesizer
-    varowner: varowner
+    owner: varowner
 spec:
   ports:
     - port: 80
@@ -41,4 +41,4 @@ spec:
       protocol: TCP
   selector:
     app: hypothesizer
-    varowner: varowner
+    owner: varowner

--- a/hypothesizer/deployments/hypothesizer.yaml
+++ b/hypothesizer/deployments/hypothesizer.yaml
@@ -1,21 +1,21 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: OWNER-hypothesizer
+  name: varowner-hypothesizer
   labels:
     app: hypothesizer
-    owner: OWNER
+    varowner: varowner
 spec:
   selector:
     matchLabels:
       app: hypothesizer
-      owner: OWNER
+      varowner: varowner
   template:
     metadata:
       labels:
         app: hypothesizer
         tier: web
-        owner: OWNER
+        varowner: varowner
     spec:
       containers:
       - name: hypothesizer
@@ -30,10 +30,10 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: OWNER-hypothesizer
+  name: varowner-hypothesizer
   labels:
     app: hypothesizer
-    owner: OWNER
+    varowner: varowner
 spec:
   ports:
     - port: 80
@@ -41,4 +41,4 @@ spec:
       protocol: TCP
   selector:
     app: hypothesizer
-    owner: OWNER
+    varowner: varowner

--- a/snack/deployments/snack.yaml
+++ b/snack/deployments/snack.yaml
@@ -4,18 +4,18 @@ metadata:
   name: varowner-snack
   labels:
     app: snack
-    varowner: varowner
+    owner: varowner
 spec:
   selector:
     matchLabels:
       app: snack
-      varowner: varowner
+      owner: varowner
   template:
     metadata:
       labels:
         app: snack
         tier: web
-        varowner: varowner
+        owner: varowner
     spec:
       containers:
       - name: snack

--- a/snack/deployments/snack.yaml
+++ b/snack/deployments/snack.yaml
@@ -1,21 +1,21 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: OWNER-snack
+  name: varowner-snack
   labels:
     app: snack
-    owner: OWNER
+    varowner: varowner
 spec:
   selector:
     matchLabels:
       app: snack
-      owner: OWNER
+      varowner: varowner
   template:
     metadata:
       labels:
         app: snack
         tier: web
-        owner: OWNER
+        varowner: varowner
     spec:
       containers:
       - name: snack

--- a/snack/skaffold.yaml
+++ b/snack/skaffold.yaml
@@ -1,0 +1,9 @@
+apiVersion: skaffold/v1alpha5
+kind: Config
+build:
+  artifacts:
+  - image: gcr.io/windmill-public-containers/servantes/snack
+deploy:
+  kubectl:
+    manifests:
+      - ./deployments/snack.yaml

--- a/spoonerisms/deployments/spoonerisms.yaml
+++ b/spoonerisms/deployments/spoonerisms.yaml
@@ -4,18 +4,18 @@ metadata:
   name: varowner-spoonerisms
   labels:
     app: spoonerisms
-    varowner: varowner
+    owner: varowner
 spec:
   selector:
     matchLabels:
       app: spoonerisms
-      varowner: varowner
+      owner: varowner
   template:
     metadata:
       labels:
         app: spoonerisms
         tier: web
-        varowner: varowner
+        owner: varowner
     spec:
       containers:
       - name: spoonerisms

--- a/spoonerisms/deployments/spoonerisms.yaml
+++ b/spoonerisms/deployments/spoonerisms.yaml
@@ -1,21 +1,21 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: OWNER-spoonerisms
+  name: varowner-spoonerisms
   labels:
     app: spoonerisms
-    owner: OWNER
+    varowner: varowner
 spec:
   selector:
     matchLabels:
       app: spoonerisms
-      owner: OWNER
+      varowner: varowner
   template:
     metadata:
       labels:
         app: spoonerisms
         tier: web
-        owner: OWNER
+        varowner: varowner
     spec:
       containers:
       - name: spoonerisms

--- a/vigoda/deployments/vigoda.yaml
+++ b/vigoda/deployments/vigoda.yaml
@@ -1,21 +1,21 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: OWNER-vigoda
+  name: varowner-vigoda
   labels:
     app: vigoda
-    owner: OWNER
+    varowner: varowner
 spec:
   selector:
     matchLabels:
       app: vigoda
-      owner: OWNER
+      varowner: varowner
   template:
     metadata:
       labels:
         app: vigoda
         tier: web
-        owner: OWNER
+        varowner: varowner
     spec:
       containers:
       - name: vigoda

--- a/vigoda/deployments/vigoda.yaml
+++ b/vigoda/deployments/vigoda.yaml
@@ -4,18 +4,18 @@ metadata:
   name: varowner-vigoda
   labels:
     app: vigoda
-    varowner: varowner
+    owner: varowner
 spec:
   selector:
     matchLabels:
       app: vigoda
-      varowner: varowner
+      owner: varowner
   template:
     metadata:
       labels:
         app: vigoda
         tier: web
-        varowner: varowner
+        owner: varowner
     spec:
       containers:
       - name: vigoda

--- a/words/deployments/words.yaml
+++ b/words/deployments/words.yaml
@@ -1,21 +1,21 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: OWNER-words
+  name: varowner-words
   labels:
     app: words
-    owner: OWNER
+    varowner: varowner
 spec:
   selector:
     matchLabels:
       app: words
-      owner: OWNER
+      varowner: varowner
   template:
     metadata:
       labels:
         app: words
         tier: web
-        owner: OWNER
+        varowner: varowner
     spec:
       containers:
       - name: words

--- a/words/deployments/words.yaml
+++ b/words/deployments/words.yaml
@@ -4,18 +4,18 @@ metadata:
   name: varowner-words
   labels:
     app: words
-    varowner: varowner
+    owner: varowner
 spec:
   selector:
     matchLabels:
       app: words
-      varowner: varowner
+      owner: varowner
   template:
     metadata:
       labels:
         app: words
         tier: web
-        varowner: varowner
+        owner: varowner
     spec:
       containers:
       - name: words


### PR DESCRIPTION
DNS names can't have uppercase characters, which has vexed me when trying to use other tools with our YAML such as skaffold.

I changed the string that m4 looks for from "OWNER" to "varowner".

I then added a `skaffold.yaml` config file to the snack service that shows what it would look like to run that service in skaffold.

All of this is to support documentation I want to write that shows how to go from skaffold to Tilt.