### PR TITLE
don't mount Snack, it should be updated via docker rebuild

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,6 @@ services:
   snack:
     build: ./snack
     command: /go/bin/snack
-    volumes:
-      - ./snack:/go/src/github.com/windmilleng/servantes/snack
     ports:
       - "8083:8083"
     environment:


### PR DESCRIPTION
Hello @jazzdan, @landism,

Please review the following commits I made in branch maiamcc/dont-mount-compiled-services:

e3a7b468e8ea79f6eae5f95b411ef5c15bcc928f (2019-01-16 11:40:44 -0500)
don't mount Snack, it should be updated via docker rebuild

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics