### PR TITLE
Add heartbeats to 2 servers

### DIFF
--- a/doggos/main.go
+++ b/doggos/main.go
@@ -7,9 +7,16 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"time"
 )
 
 func main() {
+	go func() {
+		for {
+			time.Sleep(3200 * time.Millisecond)
+			log.Printf("Heartbeat")
+		}
+	}()
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		t, err := template.ParseFiles(templatePath("index.tpl"))
 		if err != nil {

--- a/vigoda/main.go
+++ b/vigoda/main.go
@@ -7,9 +7,16 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"time"
 )
 
 func main() {
+	go func() {
+		for {
+			time.Sleep(2 * time.Second)
+			log.Printf("Server status: All good")
+		}
+	}()
 	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		time := "10:00am"
 


### PR DESCRIPTION
Often some microservice will have a heartbeat that fills up the log, which makes it even more useful to be able to dig into per-service logs. Add that so playing with Tilt seems cooler.