### PR TITLE
Remove references to composite_service

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -1,7 +1,7 @@
 # -*- mode: Python -*-
 
 """
-This Tiltfile contains 1 composite service which depends on a number of regular services.
+This Tiltfile contains one external-facing service which depends on a number of internal services.
 Here's a quick rundown of these services and their properties:
 
 * Frontend


### PR DESCRIPTION
I realized during TGIK8s that the composite_service verbiage doesn't
really make sense since we've gotten rid of it.