### PR TITLE
add a shouty sidecar to Doggos for testing multi-container stuff [ch1727]

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -14,7 +14,7 @@ Here's a quick rundown of these services and their properties:
   * Other notes: Uses static_build
 * Doggos
   * Language: Go
-  * Other notes: Has a JS component
+  * Other notes: Has a JS component, and a sidecar that yells a lot
 * Fortune
   * Language: Go
   * Other notes: Uses protobufs
@@ -64,6 +64,7 @@ docker_build('gcr.io/windmill-public-containers/servantes/emoji', 'emoji')
 docker_build('gcr.io/windmill-public-containers/servantes/words', 'words')
 docker_build('gcr.io/windmill-public-containers/servantes/secrets', 'secrets')
 docker_build('gcr.io/windmill-public-containers/servantes/sleep', 'sleeper')
+docker_build('gcr.io/windmill-public-containers/servantes/sidecar', 'sidecar')
 
 # fast builds show how we can handle complex cases quickly
 (fast_build('gcr.io/windmill-public-containers/servantes/fe',

--- a/deploy/doggos.yaml
+++ b/deploy/doggos.yaml
@@ -29,3 +29,8 @@ spec:
         resources:
           requests:
             cpu: "10m"
+      - name: sidecar
+        image: gcr.io/windmill-public-containers/servantes/sidecar
+        resources:
+          requests:
+            cpu: "10m"

--- a/sidecar/Dockerfile
+++ b/sidecar/Dockerfile
@@ -1,0 +1,4 @@
+FROM alpine
+
+ADD loud_sidecar.sh /
+ENTRYPOINT ["/loud_sidecar.sh"]

--- a/sidecar/loud_sidecar.sh
+++ b/sidecar/loud_sidecar.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+while :; do echo "I'm a loud sidecar! [$(date)]"; sleep 2; done


### PR DESCRIPTION
Hello @jazzdan,

Please review the following commits I made in branch maiamcc/sidecar:

d188448e7402daeeadd71a563f8a1facb94551da (2019-03-04 18:10:38 -0500)
add a shouty sidecar to Doggos for testing multi-container stuff [ch1727]

Code review reminders, by giving a LGTM you attest that:

* Commits are adequately tested
* Code is easy to understand and conforms to style guides
* Incomplete code is marked with TODOs
* Code is suitably instrumented with logging and metrics