### PR TITLE
rm old feature in docker compose tiltfile

### DIFF
--- a/Tiltfile.dc
+++ b/Tiltfile.dc
@@ -1,6 +1,4 @@
 # -*- mode: Python -*-
-enable_feature("team_alerts")
-
 docker_compose('docker-compose.yml')
 
 docker_build('vigoda_for_dc', 'vigoda', dockerfile='vigoda/Dockerfile.dc')


### PR DESCRIPTION
'team_alerts' feature doesn't exist anymore, so
this line was causing a Tiltfile error every time
you tried to run this Tiltfile