### PR TITLE
fix markup pip install bug

### DIFF
--- a/hypothesizer/requirements.txt
+++ b/hypothesizer/requirements.txt
@@ -4,6 +4,6 @@ gitdb2==2.0.4
 GitPython==2.1.11
 itsdangerous==0.24
 Jinja2==2.10
-MarkupSafe==1.0
+MarkupSafe==1.1
 smmap2==2.0.4
 Werkzeug==0.14.1


### PR DESCRIPTION
bump version of `MarkupSafe` to avoid a pip install error
(see [MarkupSafe#116](https://github.com/pallets/markupsafe/issues/116)